### PR TITLE
feat(faker-2663): add new keyword argument that excludes lorem ipsum …

### DIFF
--- a/doc/default/lorem.md
+++ b/doc/default/lorem.md
@@ -10,6 +10,12 @@ Faker::Lorem.words(number: 4, supplemental: true) #=> ["colloco", "qui", "vergo"
 
 Faker::Lorem.multibyte #=> 😀
 
+# Keyword arguments: exclude_words (prevent specific words from being produced)
+Faker::Lorem.words #=> ["error", "cum", "nesciunt"]
+Faker::Lorem.words(number: 4, exclude_words: 'error') #=> ["nisi", "allatus", "consequatur", "aut"]
+Faker::Lorem.words(number: 4, exclude_words: 'error, cum') #=> ["nisi", "allatus", "consequatur", "aut"]
+Faker::Lorem.words(number: 4, exclude_words: ['error', 'cum']) #=> ["nisi", "allatus", "consequatur", "aut"]
+
 # Keyword arguments: number, min_alpha, min_numeric
 Faker::Lorem.characters #=> "uw1ep04lhs0c4d931n1jmrspprf5wrj85fefue0y7y6m56b6omquh7br7dhqijwlawejpl765nb1716idmp3xnfo85v349pzy2o9rir23y2qhflwr71c1585fnynguiphkjm8p0vktwitcsm16lny7jzp9t4drwav3qmhz4yjq4k04x14gl6p148hulyqioo72tf8nwrxxcclfypz2lc58lsibgfe5w5p0xv95peafjjmm2frkhdc6duoky0aha"
 Faker::Lorem.characters(number: 10) #=> "ang9cbhoa8"

--- a/lib/faker/default/lorem.rb
+++ b/lib/faker/default/lorem.rb
@@ -28,14 +28,19 @@ module Faker
       #   Faker::Lorem.words                                    #=> ["hic", "quia", "nihil"]
       #   Faker::Lorem.words(number: 4)                         #=> ["est", "temporibus", "et", "quaerat"]
       #   Faker::Lorem.words(number: 4, supplemental: true)    #=> ["nisi", "sit", "allatus", "consequatur"]
+      #   Faker::Lorem.words(number: 4, supplemental: true, exclude_words: 'sit') #=> ["nisi", "allatus", "consequatur", "aut"]
       #
       # @faker.version 2.1.3
-      def words(number: 3, supplemental: false)
+      def words(number: 3, supplemental: false, exclude_words: nil)
         resolved_num = resolve(number)
         word_list = (
           translate('faker.lorem.words') +
           (supplemental ? translate('faker.lorem.supplemental') : [])
         )
+        if exclude_words
+          exclude_words = exclude_words.split(', ') if exclude_words.instance_of?(::String)
+          word_list -= exclude_words
+        end
         word_list *= ((resolved_num / word_list.length) + 1)
         shuffle(word_list)[0, resolved_num]
       end
@@ -103,8 +108,8 @@ module Faker
       #   Faker::Lorem.sentence(word_count: 5, supplemental: true, random_words_to_add:2)   #=> "Crinis quo cruentus velit animi vomer."
       #
       # @faker.version 2.1.3
-      def sentence(word_count: 4, supplemental: false, random_words_to_add: 0)
-        words(number: word_count + rand(random_words_to_add.to_i), supplemental: supplemental).join(locale_space).capitalize + locale_period
+      def sentence(word_count: 4, supplemental: false, random_words_to_add: 0, exclude_words: nil)
+        words(number: word_count + rand(random_words_to_add.to_i), supplemental: supplemental, exclude_words: exclude_words).join(locale_space).capitalize + locale_period
       end
 
       ##
@@ -121,8 +126,8 @@ module Faker
       #   Faker::Lorem.sentences(number: 2, supplemental: true)   #=> ["Cito cena ad.", "Solvo animus allatus."]
       #
       # @faker.version 2.1.3
-      def sentences(number: 3, supplemental: false)
-        1.upto(resolve(number)).collect { sentence(word_count: 3, supplemental: supplemental) }
+      def sentences(number: 3, supplemental: false, exclude_words: nil)
+        1.upto(resolve(number)).collect { sentence(word_count: 3, supplemental: supplemental, exclude_words: exclude_words) }
       end
 
       ##
@@ -145,8 +150,8 @@ module Faker
       #     #=> "Texo tantillus tamisium. Tribuo amissio tamisium. Facere aut canis."
       #
       # @faker.version 2.1.3
-      def paragraph(sentence_count: 3, supplemental: false, random_sentences_to_add: 0)
-        sentences(number: resolve(sentence_count) + rand(random_sentences_to_add.to_i), supplemental: supplemental).join(locale_space)
+      def paragraph(sentence_count: 3, supplemental: false, random_sentences_to_add: 0, exclude_words: nil)
+        sentences(number: resolve(sentence_count) + rand(random_sentences_to_add.to_i), supplemental: supplemental, exclude_words: exclude_words).join(locale_space)
       end
 
       ##
@@ -163,8 +168,8 @@ module Faker
       #   Faker::Lorem.paragraphs(number:2, supplemental: true)
       #
       # @faker.version 2.1.3
-      def paragraphs(number: 3, supplemental: false)
-        1.upto(resolve(number)).collect { paragraph(sentence_count: 3, supplemental: supplemental) }
+      def paragraphs(number: 3, supplemental: false, exclude_words: nil)
+        1.upto(resolve(number)).collect { paragraph(sentence_count: 3, supplemental: supplemental, exclude_words: exclude_words) }
       end
 
       ##
@@ -205,8 +210,8 @@ module Faker
       #   Faker::Lorem.question(word_count: 2, supplemental: true, random_words_to_add: 2)    #=> "Depulso uter ut?"
       #
       # @faker.version 2.1.3
-      def question(word_count: 4, supplemental: false, random_words_to_add: 0)
-        words(number: word_count + rand(random_words_to_add), supplemental: supplemental).join(' ').capitalize + locale_question_mark
+      def question(word_count: 4, supplemental: false, random_words_to_add: 0, exclude_words: nil)
+        words(number: word_count + rand(random_words_to_add), supplemental: supplemental, exclude_words: exclude_words).join(' ').capitalize + locale_question_mark
       end
 
       ##
@@ -223,8 +228,8 @@ module Faker
       #   Faker::Lorem.questions(number: 2, supplemental: true)   #=> ["Acceptus subito cetera?", "Aro sulum cubicularis?"]
       #
       # @faker.version 2.1.3
-      def questions(number: 3, supplemental: false)
-        1.upto(resolve(number)).collect { question(word_count: 3, supplemental: supplemental) }
+      def questions(number: 3, supplemental: false, exclude_words: nil)
+        1.upto(resolve(number)).collect { question(word_count: 3, supplemental: supplemental, exclude_words: exclude_words) }
       end
 
       private

--- a/test/faker/default/test_faker_lorem.rb
+++ b/test/faker/default/test_faker_lorem.rb
@@ -133,4 +133,32 @@ class TestFakerLorem < Test::Unit::TestCase
     @tester.unique.exclude(:characters, [number: 1], values)
     assert_raise(Faker::UniqueGenerator::RetryLimitExceeded) { @tester.unique.characters(number: 1) }
   end
+
+  def test_excluded_words_as_string
+    excluded_word_string = @tester.word
+    @words = @tester.words(number: 10_000, exclude_words: excluded_word_string)
+
+    @words.each { |w| assert_not_equal w, excluded_word_string }
+  end
+
+  def test_excluded_words_as_comma_delimited_string
+    excluded_words_array = @tester.words(number: 2)
+    excluded_words_string = excluded_words_array.join(', ')
+    @words = @tester.words(number: 10_000, exclude_words: excluded_words_string)
+
+    @words.each do |w|
+      assert_not_equal w, excluded_words_array[0]
+      assert_not_equal w, excluded_words_array[1]
+    end
+  end
+
+  def test_excluded_words_as_array
+    excluded_words_array = @tester.words(number: 2)
+    @words = @tester.words(number: 10_000, exclude_words: excluded_words_array)
+
+    @words.each do |w|
+      assert_not_equal w, excluded_words_array[0]
+      assert_not_equal w, excluded_words_array[1]
+    end
+  end
 end


### PR DESCRIPTION
Add new keyword argument that excludes lorem ipsum words from being produced

### Summary

This addresses issue # 2663 in the faker ruby repository here: https://github.com/faker-ruby/faker/issues/2663

